### PR TITLE
User created resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ If your application is running within a Docker container then the `configure` fu
                          :ddb (slurp "./resources/config/schema.yaml")})))
 ```
 
+If you already have a part of your application that creates AWS resources, then you'll not need the Spurious helper to create those resources; but you will want to make sure that you call the Spurious helper's `core/configure` function *before* that part of your application is executed. This will allow the helper to still configure settings that allow the AWS SDK to work with the Spurious services.
+
+The `core/configure` function has multi-arity and so you can call it without the map data structure, like so:
+
+```clj
+(core/configure :app)
+```
+
+> Note: the Java SDK, which Spurious utilises under the covers, requires that each SDK API function is passed the same auth credentials (access/secret keys and endpoint). This means your application will need to ensure it uses the right credentials (the example app linked to above shows that you can use `[spurious-aws-sdk-helper.utils :refer [endpoint cred]]` for dev mode)
+
 ## Testing locally
 
 Clone this repository, make changes and then run:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spurious-aws-sdk-helper "0.1.0"
+(defproject spurious-aws-sdk-helper "0.2.0"
   :description "A Clojure helper class for configuring a Clojure application that uses the AWS SDK (via Amazonica) to talk to the Spurious services (https://github.com/spurious-io/spurious)"
   :url "https://github.com/Integralist/spurious-clojure-aws-sdk-helper"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject spurious-aws-sdk-helper "0.1.0"
-  :description "A Clojure helper class for configuring a Clojure AWS SDK (Amazonica) to talk to the Spurious services (https://github.com/spurious-io/spurious)"
+  :description "A Clojure helper class for configuring a Clojure application that uses the AWS SDK (via Amazonica) to talk to the Spurious services (https://github.com/spurious-io/spurious)"
   :url "https://github.com/Integralist/spurious-clojure-aws-sdk-helper"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/spurious_aws_sdk_helper/core.clj
+++ b/src/spurious_aws_sdk_helper/core.clj
@@ -4,7 +4,11 @@
             [spurious-aws-sdk-helper.dynamodb :as ddb]
             [clj-yaml.core :as yaml]))
 
-(defn configure [type opts]
-  (if-let [name   (:s3  opts)] (s3/setup  type name))
-  (if-let [name   (:sqs opts)] (sqs/setup type name))
-  (if-let [schema (:ddb opts)] (ddb/setup type (yaml/parse-string schema))))
+(defn configure
+  ([type]
+   (s3/setup  type)
+   (ddb/setup type))
+  ([type opts]
+   (if-let [name   (:s3  opts)] (s3/setup  type name))
+   (if-let [name   (:sqs opts)] (sqs/setup type name))
+   (if-let [schema (:ddb opts)] (ddb/setup type (yaml/parse-string schema)))))

--- a/src/spurious_aws_sdk_helper/dynamodb.clj
+++ b/src/spurious_aws_sdk_helper/dynamodb.clj
@@ -5,11 +5,14 @@
 (defn resource [type]
   (endpoint type :spurious-dynamo))
 
-(defn setup [type schema]
-  (try
-    (let [credentials (cred (resource type))]
-      (set-signer-region-override credentials "eu-west-1")
-      (create-table credentials schema)
-      (list-tables credentials))
-    (catch Exception e
-      (prn "DynamoDB Error: chances are you're creating a table that already exists"))))
+(defn setup
+  ([type]
+   (set-signer-region-override (cred (resource type)) "eu-west-1"))
+  ([type schema]
+   (try
+     (let [credentials (cred (resource type))]
+       (set-signer-region-override credentials "eu-west-1")
+       (create-table credentials schema)
+       (list-tables credentials))
+     (catch Exception e
+       (prn "DynamoDB Error: chances are you're creating a table that already exists")))))

--- a/src/spurious_aws_sdk_helper/s3.clj
+++ b/src/spurious_aws_sdk_helper/s3.clj
@@ -5,10 +5,13 @@
 (defn resource [type]
   (endpoint type :spurious-s3))
 
-(defn setup [type name]
-  (try
-    (let [credentials (cred (resource type))]
-      (set-s3client-options credentials :path-style-access true)
-      (create-bucket credentials name))
-    (catch Exception e
-      (prn "S3 Error: chances are you're creating a bucket that already exists"))))
+(defn setup
+  ([type]
+   (set-s3client-options (cred (resource type)) :path-style-access true))
+  ([type name]
+   (try
+     (let [credentials (cred (resource type))]
+       (set-s3client-options credentials :path-style-access true)
+       (create-bucket credentials name))
+     (catch Exception e
+       (prn "S3 Error: chances are you're creating a bucket that already exists")))))


### PR DESCRIPTION
![getinsertpic.com](http://media1.giphy.com/media/Up1NuCvxczL44/200.gif)
## Problem

As pointed out by @jakechampion: the helper forced consumers to construct resources by passing a map data structure into the `core/configure` function.
## Solution

Create a multi-arity function that calls only the essential parts of the helper that enables the Spurious services to work with the AWS SDK.

[See the example application PR](https://github.com/Integralist/spurious-clojure-example/pull/1), which demonstrates this update.
## Release

If this PR is merged then this will result in a new minor version (as technically this will be new functionality; hence the update to the minor version; but it's not backwards incompatible nor does it cause breaking changes, so no need to update the major version). 

So effectively we'll move from `0.1.0` up to `0.2.0`.
